### PR TITLE
chore: emphasize docker deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: setup run test fmt build up down schema
 
 setup:
-	python -m venv .venv && . .venv/bin/activate && pip install -e .[dev] && pre-commit install
+	pip install -r requirements.txt && pre-commit install
 
 run:
-	uvicorn soc_agent.webapp:app --host $${APP_HOST:-0.0.0.0} --port $${APP_PORT:-8000}
+	docker compose up --build
 
 test:
-	pytest -q --cov soc_agent --cov-report=term-missing
+	docker compose run --rm app pytest -q --cov soc_agent --cov-report=term-missing
 
 fmt:
 	ruff check --fix && ruff format
@@ -16,10 +16,10 @@ build:
 	docker build -t soc-agent:latest .
 
 up:
-	docker-compose up -d --build
+	docker compose up -d --build
 
 down:
-	docker-compose down
+	docker compose down
 
 schema:
 	python scripts/gen_schema.py > schema.json

--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@ FastAPI webhook that ingests security events, enriches IOCs (OTX / VirusTotal / 
 
 ## 1) Getting Started
 ```bash
-# clone & setup
-python -m venv .venv && source .venv/bin/activate
-pip install -e .[dev]
-pre-commit install
-
-# configure
+# configure environment
 cp .env.example .env  # edit as needed
 
-# run
-uvicorn soc_agent.webapp:app --host 0.0.0.0 --port 8000
+# build & run with docker-compose
+docker compose up --build
+# or
+make up
 
-# test
-pytest -q --cov soc_agent --cov-report=term-missing
+# run tests inside the container
+docker compose run --rm app pytest -q --cov soc_agent --cov-report=term-missing
+
+# stop services
+docker compose down
+# or
+make down
+```
 
 ### Vendor Adapters (Wazuh & CrowdStrike)
 The service auto-detects and normalizes common vendor payloads to the internal `EventIn` schema before scoring.


### PR DESCRIPTION
## Summary
- refocus README on docker-compose workflow and remove venv setup
- update Makefile to run and test via docker compose

## Testing
- `pre-commit run --files README.md Makefile` *(fails: fatal: unable to access 'https://github.com/astral-sh/ruff-pre-commit/': CONNECT tunnel failed, response 403)*
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae4a981d64832e824749d490f707e3