### PR TITLE
Include source files in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Exclude VCS and build system files
+.git
+.gitignore
+
+# Python caches and build artifacts
+__pycache__/
+*.py[cod]
+*.so
+build/
+dist/
+*.egg-info/
+
+# Virtual environment directories
+.env
+.venv
+venv/
+
+# Test files
+/tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.12-slim AS builder
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /build
 COPY pyproject.toml README.md /build/
+COPY src/ /build/src/
 RUN pip install --no-cache-dir -U pip setuptools wheel \
     && pip wheel --no-cache-dir --wheel-dir /wheels .
 


### PR DESCRIPTION
## Summary
- Copy source code into Docker build context so `pip wheel` can build package
- Add .dockerignore to prevent sending unnecessary files during Docker builds

## Testing
- `pre-commit run --files Dockerfile .dockerignore` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5eee8cb08832eb84a52129b37c994