### PR TITLE
Document host-based testing and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run:
 	docker compose up --build
 
 test:
-	docker compose run --rm app pytest -q --cov soc_agent --cov-report=term-missing
+	PYTHONPATH=src pytest -q --cov soc_agent --cov-report=term-missing
 
 fmt:
 	ruff check --fix && ruff format

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ FastAPI webhook that ingests security events, enriches IOCs (OTX / VirusTotal / 
    curl http://localhost:8000/readyz
    ```
 
-5. **Run tests inside the container (optional)**
+5. **Run tests (requires development dependencies)**
+
+   The runtime Docker image only includes production packages. To execute the
+   test suite you need a Python environment with the development dependencies
+   installed. This can be a dedicated development image or your local host.
+
+   On the host:
+
    ```bash
-   docker compose run --rm app pytest -q --cov soc_agent --cov-report=term-missing
+   pip install -r requirements.txt
+   PYTHONPATH=src pytest -q --cov soc_agent --cov-report=term-missing
+   # or
+   make test
    ```
 
 6. **Stop services**


### PR DESCRIPTION
## Summary
- explain that running tests requires development dependencies
- show how to run tests on the host with `pip install -r requirements.txt` and `make test`
- run pytest directly from Makefile using host Python

## Testing
- `pre-commit run --files README.md Makefile` *(fails: unable to access https://github.com/astral-sh/ruff-pre-commit/)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b5eee817c0832eaa065ef047189a98