### PR TITLE
build: copy source before wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM python:3.12-slim AS builder
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /build
 COPY pyproject.toml README.md /build/
+RUN pip install --no-cache-dir -U pip setuptools wheel
 COPY src/ /build/src/
-RUN pip install --no-cache-dir -U pip setuptools wheel \
-    && pip wheel --no-cache-dir --wheel-dir /wheels .
+RUN pip wheel --no-cache-dir --wheel-dir /wheels .
 
 FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- ensure source copied before building wheel in Docker builder stage for soc_agent

## Testing
- `pre-commit run --files Dockerfile` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'soc_agent')*
- `docker build -t socai:test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6471790832e947b13237a08a7c2