### PR TITLE
Document dev test dependencies and add docker test option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ run:
 	docker compose up --build
 
 test:
-	PYTHONPATH=src pytest -q --cov soc_agent --cov-report=term-missing
+	@if [ "$(docker)" = "1" ]; then \
+		docker build --target dev -t soc-agent:dev . && \
+		docker run --rm -v $$(pwd):/app -w /app soc-agent:dev pytest -q --cov soc_agent --cov-report=term-missing; \
+	else \
+		PYTHONPATH=src pytest -q --cov soc_agent --cov-report=term-missing; \
+	fi
 
 fmt:
 	ruff check --fix && ruff format

--- a/README.md
+++ b/README.md
@@ -34,16 +34,22 @@ FastAPI webhook that ingests security events, enriches IOCs (OTX / VirusTotal / 
 5. **Run tests (requires development dependencies)**
 
    The runtime Docker image only includes production packages. To execute the
-   test suite you need a Python environment with the development dependencies
-   installed. This can be a dedicated development image or your local host.
+   test suite you need a Python environment with the development extras. Install
+   them on the host or use the `dev` Docker build target.
 
    On the host:
 
    ```bash
-   pip install -r requirements.txt
+   pip install -e .[dev]
    PYTHONPATH=src pytest -q --cov soc_agent --cov-report=term-missing
    # or
    make test
+   ```
+
+   In Docker:
+
+   ```bash
+   make test docker=1
    ```
 
 6. **Stop services**


### PR DESCRIPTION
## Summary
- clarify in README that tests need development extras or dev Docker target
- let `make test` run locally or inside a `docker build --target dev` image when `docker=1`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f6454540832eb8528018732267ac