### PR TITLE
fix: avoid resetting root logger in IntelClient

### DIFF
--- a/src/soc_agent/intel/client.py
+++ b/src/soc_agent/intel/client.py
@@ -5,13 +5,18 @@ from typing import Any, Dict, List
 import requests
 
 from ..config import SETTINGS
-from ..logging import setup_json_logging
 from .providers import abuseipdb, otx, virustotal
 
 
 class IntelClient:
     def __init__(self):
-        setup_json_logging()  # idempotent
+        """Initialize the intelligence client.
+
+        Logging should be configured by the application using this client. To
+        avoid unintentionally overriding existing logging handlers, this
+        constructor does not configure logging and simply uses whatever
+        configuration is already in place.
+        """
         self.session = requests.Session()
 
     def enrich_ip(self, ip: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- avoid resetting root logger during `IntelClient` initialization
- document expectation to use existing logging configuration

## Testing
- `ruff check src/soc_agent/intel/client.py --fix`
- `ruff format src/soc_agent/intel/client.py`
- `pre-commit run --files src/soc_agent/intel/client.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b600e64770832e8ef32d8ab7163ecd